### PR TITLE
Add configurable data paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,10 @@
+# Artist Calendar
+
+This repository contains scripts for scraping Instagram posts, classifying tour date images, and generating Markdown summaries. Paths for data and configuration can be customized using environment variables.
+
+## Configuration
+
+- `BASE_DATA_DIR` – Base directory for generated CSV files, images, and Markdown files. Defaults to `data` in the current working directory.
+- `ENV_PATH` – Path to a `.env` file containing API keys such as `GEMINI_API_KEY`. Defaults to `.env`.
+
+Create the directories or override these variables before running the scripts. The `.env` file should define `GEMINI_API_KEY` used by the AI features.

--- a/src/a_ig_scraper.py
+++ b/src/a_ig_scraper.py
@@ -6,6 +6,7 @@ import time
 from tqdm import tqdm
 import re
 import os
+BASE_DATA_DIR=os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
 import random
 
 class GetInstagramProfile:
@@ -84,5 +85,5 @@ if __name__ == "__main__":
         username="retrospect_official",
         since="2024-11-01",
         until="2024-12-01",
-        output_folder="/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/raw"
+        output_folder="os.path.join(BASE_DATA_DIR, 'CSV', 'raw')"
     )

--- a/src/a_ig_scraper_backup.py
+++ b/src/a_ig_scraper_backup.py
@@ -13,6 +13,7 @@ import re
 import os
 import random
 
+BASE_DATA_DIR=os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
 class GetInstagramProfile:
     def __init__(self, loader=None) -> None:
         """
@@ -160,5 +161,6 @@ if __name__=="__main__":
     #cls.get_post_info_csv(username="retrospect_official", since="2024-11-01", until="2024-12-01")
 
     ### แบบกำหนด folder ของ output
-    cls.get_post_info_csv(username="retrospect_official", since="2024-11-01", until="2024-12-01", output_folder="/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/raw")
+    cls.get_post_info_csv(username="retrospect_official", since="2024-11-01", until="2024-12-01", output_folder="os.path.join(BASE_DATA_DIR, 'CSV', 'raw')")
 """
+

--- a/src/a_pipe.py
+++ b/src/a_pipe.py
@@ -5,6 +5,8 @@ from image_to_markdown import csv_to_markdown_with_extracted_data
 import os
 import instaloader
 
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+
 if __name__ == "__main__":
     # Initialize Instaloader
     loader = instaloader.Instaloader()
@@ -44,9 +46,9 @@ if __name__ == "__main__":
     until = "2024-12-31"
 
     # Base folders for outputs
-    base_raw_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/raw"
-    base_classified_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/classified"
-    base_markdown_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateMarkdown"
+    base_raw_folder = os.path.join(BASE_DATA_DIR, "CSV", "raw")
+    base_classified_folder = os.path.join(BASE_DATA_DIR, "CSV", "classified")
+    base_markdown_folder = os.path.join(BASE_DATA_DIR, "TourDateMarkdown")
 
     # Ensure all base folders exist
     os.makedirs(base_raw_folder, exist_ok=True)

--- a/src/ig_scraper.py
+++ b/src/ig_scraper.py
@@ -16,6 +16,7 @@ import time
 from tqdm import tqdm
 import re
 import os
+BASE_DATA_DIR=os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
 
 
 class GetInstagramProfile:
@@ -160,5 +161,5 @@ if __name__=="__main__":
     #cls.get_post_info_csv(username="retrospect_official", since="2024-11-01", until="2024-12-01")
 
     ### แบบกำหนด folder ของ output
-    cls.get_post_info_csv(username="retrospect_official", since="2024-11-01", until="2024-12-01", output_folder="/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/raw")
+    cls.get_post_info_csv(username="retrospect_official", since="2024-11-01", until="2024-12-01", output_folder="os.path.join(BASE_DATA_DIR, 'CSV', 'raw')")
 """

--- a/src/ig_tour_date_pipeline.py
+++ b/src/ig_tour_date_pipeline.py
@@ -5,6 +5,8 @@ from image_to_markdown import csv_to_markdown_with_extracted_data
 import os
 import instaloader
 
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+
 if __name__ == "__main__":
     # Initialize Instaloader
     loader = instaloader.Instaloader()
@@ -43,9 +45,9 @@ if __name__ == "__main__":
     until = "2024-12-31"
 
     # Base folders for outputs
-    base_raw_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/raw"
-    base_classified_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/classified"
-    base_markdown_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateMarkdown"
+    base_raw_folder = os.path.join(BASE_DATA_DIR, "CSV", "raw")
+    base_classified_folder = os.path.join(BASE_DATA_DIR, "CSV", "classified")
+    base_markdown_folder = os.path.join(BASE_DATA_DIR, "TourDateMarkdown")
 
     # Ensure all base folders exist
     os.makedirs(base_raw_folder, exist_ok=True)

--- a/src/image_to_markdown.py
+++ b/src/image_to_markdown.py
@@ -6,7 +6,9 @@ import google.generativeai as genai
 import requests
 
 # Load environment variables
-load_dotenv('/Users/kokoabassplayer/Desktop/python/.env')
+ENV_PATH = os.environ.get("ENV_PATH", ".env")
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+load_dotenv(ENV_PATH)
 genai.configure(api_key=os.environ.get("GEMINI_API_KEY"))
 
 if not os.environ.get("GEMINI_API_KEY"):
@@ -129,8 +131,10 @@ def csv_to_markdown_with_extracted_data(csv_file):
     else:
         year_month = "unknown"
 
-    output_markdown_file = f"/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateMarkdown/{base_name}_{year_month}.md"
-    image_folder = f"/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateImage/{base_name}"
+    markdown_dir = os.path.join(BASE_DATA_DIR, "TourDateMarkdown")
+    image_folder = os.path.join(BASE_DATA_DIR, "TourDateImage", base_name)
+    os.makedirs(markdown_dir, exist_ok=True)
+    output_markdown_file = os.path.join(markdown_dir, f"{base_name}_{year_month}.md")
 
     print(f"Markdown will be saved to: {output_markdown_file}")
     print(f"Images will be stored in: {image_folder}")
@@ -182,13 +186,11 @@ def csv_to_markdown_with_extracted_data(csv_file):
 """
 # Example usage
 if __name__ == "__main__":
-    csv_file = "/Users/kokoabassplayer/Desktop/python/palmy_classified.csv"  # Input CSV file
+    csv_file = os.path.join(BASE_DATA_DIR, "palmy_classified.csv")  # Example input
     csv_to_markdown_with_extracted_data(csv_file)
 """
 
 import json
-import os
-from dotenv import load_dotenv
 import google.generativeai as genai
 
 
@@ -250,4 +252,5 @@ def summarize_markdown_to_json_gemini(content):
         return json_data
     except json.JSONDecodeError:
         return response.text
+
 

--- a/src/markdown_wrapper.py
+++ b/src/markdown_wrapper.py
@@ -1,12 +1,14 @@
 import os
 import glob
 
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+
 def append_to_single_markdown():
     # Specify the directory containing the input markdown files
-    input_directory = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateMarkdown"
+    input_directory = os.path.join(BASE_DATA_DIR, "TourDateMarkdown")
     
     # Specify the output directory
-    output_directory = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CombinedMarkdown"
+    output_directory = os.path.join(BASE_DATA_DIR, "CombinedMarkdown")
 
     # Specify the output file name
     output_file = "combined_tour_dates.md"
@@ -30,3 +32,4 @@ def append_to_single_markdown():
 
 # You can now call the function without any arguments
 append_to_single_markdown()
+

--- a/src/summarize_markdown.py
+++ b/src/summarize_markdown.py
@@ -2,7 +2,9 @@ import os
 import google.generativeai as genai
 from dotenv import load_dotenv
 
-load_dotenv('/Users/kokoabassplayer/Desktop/python/.env')
+ENV_PATH = os.environ.get("ENV_PATH", ".env")
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+load_dotenv(ENV_PATH)
 
 genai.configure(api_key=os.environ.get("GEMINI_API_KEY"))
 
@@ -104,5 +106,6 @@ def process_markdown_folder(folder_path):
                 print("\n" + "="*50 + "\n")
 
 if __name__ == "__main__":
-    folder_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CombinedMarkdown"
+    folder_path = os.path.join(BASE_DATA_DIR, "CombinedMarkdown")
     process_markdown_folder(folder_path)
+

--- a/src/test classifer solo.py
+++ b/src/test classifer solo.py
@@ -1,8 +1,9 @@
 from tour_date_classifier import tour_date_classifier
 import os
+BASE_DATA_DIR=os.environ.get('BASE_DATA_DIR', os.path.join(os.getcwd(), 'data'))
 
 # Example image path
-image_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image/palmy202412.png"
+image_path = os.path.join(BASE_DATA_DIR, 'image', 'palmy202412.png')
 #image_path = "https://www.facebook.com/photo.php?fbid=1121851509302448&set=pb.100044328284924.-2207520000&type=3"
 
 # Extract the file name from the image path
@@ -13,3 +14,4 @@ output = tour_date_classifier(image_path)
 
 if output:
     print(f"file name {filename}: ", output)
+

--- a/src/test classifier loop.py
+++ b/src/test classifier loop.py
@@ -1,9 +1,10 @@
 from tour_date_classifier import tour_date_classifier
 import os
+BASE_DATA_DIR=os.environ.get('BASE_DATA_DIR', os.path.join(os.getcwd(), 'data'))
 
 # Example use
 # Path to folder containing images
-folder_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image"
+folder_path = os.path.join(BASE_DATA_DIR, 'image')
 
 # Loop through all image files in the folder
 for filename in os.listdir(folder_path):

--- a/src/test markdown.py
+++ b/src/test markdown.py
@@ -1,9 +1,11 @@
+import os
+BASE_DATA_DIR=os.environ.get('BASE_DATA_DIR', os.path.join(os.getcwd(), 'data'))
 
 from image_to_markdown import image_to_markdown
 # Example image path
 #image_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image/sweetmullet202412.png"
 #image_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image/palmy202412.png"
-image_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image/retrospect.jpg"
+image_path = os.path.join(BASE_DATA_DIR, 'image', 'retrospect.jpg')
 #image_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image/parkinson.jpg"
 
 
@@ -11,3 +13,4 @@ image_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image/retrosp
 markdown_output = image_to_markdown(image_path)
 if markdown_output:
     print("Markdown Conversion:\n", markdown_output)
+

--- a/src/test_classifier_CSV.py
+++ b/src/test_classifier_CSV.py
@@ -1,8 +1,11 @@
 from tour_date_csv_utils import classify_images
+import os
+
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
 
 # Use the function with specified CSV files
-input_csv = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/raw/retrospect_official_2024-11-01_to_2024-12-01.csv"
-output_folder = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/CSV/classified"
+input_csv = os.path.join(BASE_DATA_DIR, "CSV", "raw", "retrospect_official_2024-11-01_to_2024-12-01.csv")
+output_folder = os.path.join(BASE_DATA_DIR, "CSV", "classified")
 classify_images(
     input_csv = input_csv,
     output_folder = output_folder #, output_csv

--- a/src/test_extract_csv
+++ b/src/test_extract_csv
@@ -1,6 +1,9 @@
 from image_to_markdown import csv_to_markdown_with_extracted_data
+import os
+BASE_DATA_DIR=os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
 
 # Example usage
 if __name__ == "__main__":
-    csv_file = "/Users/kokoabassplayer/Desktop/python/palmy_classified.csv"  # Input CSV file
+    csv_file = os.path.join(BASE_DATA_DIR, 'palmy_classified.csv')  # Input CSV file
     csv_to_markdown_with_extracted_data(csv_file)
+

--- a/src/tour_date_classifier.py
+++ b/src/tour_date_classifier.py
@@ -2,7 +2,9 @@ import os
 import google.generativeai as genai
 from dotenv import load_dotenv
 
-load_dotenv('/Users/kokoabassplayer/Desktop/python/.env')
+ENV_PATH = os.environ.get("ENV_PATH", ".env")
+BASE_DATA_DIR = os.environ.get("BASE_DATA_DIR", os.path.join(os.getcwd(), "data"))
+load_dotenv(ENV_PATH)
 
 genai.configure(api_key=os.environ.get("GEMINI_API_KEY"))
 
@@ -96,7 +98,7 @@ def tour_date_classifier(image_path):
 """
 # Example use
 # Path to folder containing images
-folder_path = "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/image"
+folder_path = os.path.join(BASE_DATA_DIR, "image")
 
 # Loop through all image files in the folder
 for filename in os.listdir(folder_path):
@@ -106,3 +108,4 @@ for filename in os.listdir(folder_path):
         if result is not None:
             print(f"Image: {filename}, is tour date: {result}")
 """
+


### PR DESCRIPTION
## Summary
- use `BASE_DATA_DIR` and `ENV_PATH` vars across scripts
- remove hard-coded absolute paths
- document configuration in README

## Testing
- `python -m compileall -q src`

------
https://chatgpt.com/codex/tasks/task_e_684e7226cf28832c9bac0a0ecfddab95