### PR TITLE
Fix markdown_wrapper execution on import

### DIFF
--- a/src/markdown_wrapper.py
+++ b/src/markdown_wrapper.py
@@ -28,5 +28,6 @@ def append_to_single_markdown():
 
     print(f"All markdown files have been appended to {output_path}")
 
-# You can now call the function without any arguments
-append_to_single_markdown()
+# You can now call the function directly when running this file
+if __name__ == "__main__":
+    append_to_single_markdown()


### PR DESCRIPTION
## Summary
- only run `append_to_single_markdown` when `markdown_wrapper.py` is executed directly

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_684e75761ff4832c9df3b1fd1e812907