### PR TITLE
Add CLI app to run IG scraping pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 This project provides a set of scripts for scraping Instagram data and
 converting it to Markdown. Some scripts require Instagram login
-credentials.
+credentials. A small command line application is available under
+`src/app.py` to run the full pipeline.
 
 ## Environment Variables
 
-Before running `src/ig_tour_date_pipeline.py` or `src/a_pipe.py`, set
+Before running `src/app.py`, `src/ig_tour_date_pipeline.py` or `src/a_pipe.py`, set
 the following variables in your environment or in a `.env` file:
 
 - `IG_USERNAME` – Instagram username used for authentication
@@ -14,3 +15,17 @@ the following variables in your environment or in a `.env` file:
 
 These scripts load environment variables using `python-dotenv`, so you
 may create a `.env` file with these keys or export them in your shell.
+
+## Example usage
+
+To run the full pipeline for one or more artists:
+
+```bash
+python src/app.py \
+    --artists retrospect_official,another_band \
+    --since 2024-01-01 --until 2024-12-31 \
+    --output output --env-file .env
+```
+
+The generated CSV and Markdown files will be written under the
+specified output directory.

--- a/src/app.py
+++ b/src/app.py
@@ -1,0 +1,92 @@
+import argparse
+import os
+from dotenv import load_dotenv
+import instaloader
+
+from ig_scraper import GetInstagramProfile
+from tour_date_csv_utils import classify_images
+from image_to_markdown import csv_to_markdown_with_extracted_data
+
+
+def run_pipeline(artists, since, until, output_base):
+    loader = instaloader.Instaloader()
+    username = os.environ.get("IG_USERNAME")
+    password = os.environ.get("IG_PASSWORD")
+    if not username or not password:
+        raise SystemExit("IG_USERNAME or IG_PASSWORD not set")
+
+    loader.login(username, password)
+
+    base_raw = os.path.join(output_base, "raw")
+    base_classified = os.path.join(output_base, "classified")
+    base_markdown = os.path.join(output_base, "markdown")
+
+    os.makedirs(base_raw, exist_ok=True)
+    os.makedirs(base_classified, exist_ok=True)
+    os.makedirs(base_markdown, exist_ok=True)
+
+    scraper = GetInstagramProfile(loader)
+
+    for artist in artists:
+        raw_folder = os.path.join(base_raw, artist)
+        os.makedirs(raw_folder, exist_ok=True)
+        raw_csv = os.path.join(raw_folder, f"{artist}_{since}_to_{until}.csv")
+        scraper.get_post_info_csv(
+            username=artist,
+            since=since,
+            until=until,
+            output_folder=raw_folder,
+        )
+
+        classified_folder = os.path.join(base_classified, artist)
+        os.makedirs(classified_folder, exist_ok=True)
+        classified_csv = os.path.join(
+            classified_folder,
+            f"{artist}_{since}_to_{until}_classified.csv",
+        )
+        classify_images(
+            input_csv=raw_csv,
+            output_csv=classified_csv,
+            output_folder=classified_folder,
+        )
+
+        markdown_file = os.path.join(
+            base_markdown, f"{artist}_{since}_to_{until}.md"
+        )
+        image_folder = os.path.join(base_markdown, "images", artist)
+        csv_to_markdown_with_extracted_data(
+            classified_csv,
+            output_markdown_file=markdown_file,
+            image_folder=image_folder,
+        )
+
+    print("Pipeline completed.")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Run the Artist Calendar pipeline")
+    parser.add_argument("--artists", required=True, help="Comma separated Instagram usernames")
+    parser.add_argument("--since", required=True, help="Start date YYYY-MM-DD")
+    parser.add_argument("--until", required=True, help="End date YYYY-MM-DD")
+    parser.add_argument(
+        "--output",
+        default="output",
+        help="Base directory for generated files",
+    )
+    parser.add_argument(
+        "--env-file",
+        help="Optional path to .env file containing IG_USERNAME and IG_PASSWORD",
+    )
+    args = parser.parse_args()
+
+    if args.env_file:
+        load_dotenv(args.env_file)
+    else:
+        load_dotenv()
+
+    artists = [a.strip() for a in args.artists.split(",") if a.strip()]
+    run_pipeline(artists, args.since, args.until, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/image_to_markdown.py
+++ b/src/image_to_markdown.py
@@ -86,45 +86,50 @@ def download_image(image_url, save_path):
         return False
 
 
-def csv_to_markdown_with_extracted_data(csv_file):
-    """
-    Processes a CSV file, downloads images flagged with is_tour_date == 1,
-    extracts data from the images, and generates Markdown content.
+def csv_to_markdown_with_extracted_data(
+    csv_file, output_markdown_file=None, image_folder=None
+):
+    """Convert a classified CSV file into a Markdown file.
 
-    Args:
-        csv_file (str): Path to the CSV file.
+    The function downloads images flagged with ``is_tour_date == 1`` and uses
+    :func:`image_to_markdown` to extract text from those images. The extracted
+    content is written to a Markdown file alongside basic metadata from the CSV.
+
+    Parameters
+    ----------
+    csv_file : str
+        Path to the classified CSV file.
+    output_markdown_file : str, optional
+        Path of the Markdown file to write. If not provided, a file named
+        ``<csv_file_basename>_<YYYY_MM>.md`` will be created in the current
+        directory.
+    image_folder : str, optional
+        Directory used to store downloaded images. If not provided, a folder
+        named ``<csv_file_basename>`` inside ``image_output`` in the current
+        directory will be used.
     """
-    # Generate output paths based on the input CSV file name
     base_name = os.path.splitext(os.path.basename(csv_file))[0]
 
-    # Load the CSV file
     data = pd.read_csv(csv_file)
 
-    # Check required columns
     required_columns = ["Profile", "Image URL", "URL", "is_tour_date", "Date"]
     if not all(col in data.columns for col in required_columns):
         raise ValueError(
             f"The CSV file must contain the following columns: {required_columns}"
         )
 
-    # Filter rows with is_tour_date == 1
     tour_date_images = data[data["is_tour_date"] == 1]
 
-    # Extract year and month from the first valid date
     if not tour_date_images.empty:
         first_date = pd.to_datetime(tour_date_images.iloc[0]["Date"])
         year_month = first_date.strftime("%Y_%m")
     else:
         year_month = "unknown"
 
-    output_markdown_file = os.path.join(
-        "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateMarkdown",
-        f"{base_name}_{year_month}.md",
-    )
-    image_folder = os.path.join(
-        "/Users/kokoabassplayer/Desktop/python/ArtistCalendar/TourDateImage",
-        base_name,
-    )
+    if output_markdown_file is None:
+        output_markdown_file = f"{base_name}_{year_month}.md"
+    if image_folder is None:
+        image_folder = os.path.join("image_output", base_name)
 
     print(f"Markdown will be saved to: {output_markdown_file}")
     print(f"Images will be stored in: {image_folder}")


### PR DESCRIPTION
## Summary
- implement `csv_to_markdown_with_extracted_data` with configurable paths
- add `src/app.py` CLI for running the full Instagram scraping pipeline
- document the new app usage in the README

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: API key not found)*

------
https://chatgpt.com/codex/tasks/task_e_684e79ab8494832c81817a62ea4fff4d